### PR TITLE
Removed flicker from slash command hiding

### DIFF
--- a/src/js/feature/pageElements.js
+++ b/src/js/feature/pageElements.js
@@ -521,8 +521,31 @@ function disableSlashMenuEvent(e) {
   const slashKey = "/";
   if (e.key === slashKey) {
     // hide menu before it's appearing
+    // DEV: Click off first to avoid timing issues
     e.target.click();
     console.info("slash menu hid");
+
+    // Create a temporary stylesheet to handle annoying flicker issues
+    const styleEl = document.createElement('style');
+    styleEl.innerHTML = `
+      .notion-overlay-container.notion-default-overlay-container {
+        /* Hide menu temporarily showing in Firefox */
+        display: none;
+      }
+
+      .notion-frame .notion-scroller {
+        /* Prevent left/right toggle flicker */
+        overflow: auto !important;
+      }
+    `;
+    document.body.appendChild(styleEl);
+
+    // Reveal the overlay again for more interactions
+    // DEV: requestAnimationFrame is too fast, overlay still shows otherwise
+    //   For more precision, we could watch for the overlay to happen
+    setTimeout(() => {
+      document.body.removeChild(styleEl);
+    }, 300)
   }
 }
 


### PR DESCRIPTION
First off, thank you for writing this. Notion's slash command was driving me up the wall =) After installing, I noticed there was still a menu briefly popping up and some left/right flicker.

I've added CSS rules to remove those while the overlay shows/hides from the DOM. This has only been tested in Firefox on Linux Mint, unsure solutions work elsewhere too.

In this PR:

- Visually hide overlay to prevent any flicker visibility
- Force no `overflow: auto`/`hide` changes to prevent scrollbar hiding/showing, leading to left/right flicker