### PR TITLE
Hide Corner AI Button

### DIFF
--- a/src/js/feature/pageElements.js
+++ b/src/js/feature/pageElements.js
@@ -6,6 +6,7 @@ import {
 } from "../utility";
 
 const notionHelpBtnCls = ".notion-help-button";
+const notionAiBtnCls = ".notion-ai-button"
 const notionAppId = "#notion-app";
 
 // To add theme based color: check indentationLines sass class
@@ -157,6 +158,29 @@ export function bolderTextInDark(isEnabled) {
             el.classList.remove("bolder");
           }
           // console.log(`${notionAppInner} style is ${el.style.display}`);
+        }
+        return null;
+      })
+      .catch((e) => console.log(e));
+  } catch (e) {
+    console.log(e);
+  }
+}
+
+export function hideAiBtn(isHidden) {
+  try {
+    console.log(`feature: hideAiBtn: ${isHidden}`);
+
+    onElementLoaded(notionAiBtnCls)
+      .then((isPresent) => {
+        if (isPresent) {
+          const el = getElement(notionAiBtnCls);
+          if (isHidden) {
+            el.style.display = "none";
+          } else {
+            el.style.display = "flex";
+          }
+          console.log(`${notionAiBtnCls} style is ${el.style.display}`);
         }
         return null;
       })

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -2,6 +2,7 @@
 export const defaultSettings = {
   displayOutline: true,
   hideHelpBtn: false,
+  hideAiBtn: false,
   bolderTextInDark: false,
   smallText: false,
   fullWidth: false,
@@ -137,6 +138,12 @@ export const settingDetails = [
   {
     func: "hideHelpBtn",
     name: "Hide Help button from pages",
+    desc: "",
+    pf: false,
+  },
+  {
+    func: "hideAiBtn",
+    name: "Hide AI Assistant Q&A button from pages",
     desc: "",
     pf: false,
   },


### PR DESCRIPTION
Hey there, thanks for the great extension!

Notion recently replaced the help button in the bottom right corner with an AI Q&A assistant button. This PR adds an option to remove the new button.