### PR TITLE
fix: Update Chrome Web Store URLs to new chromewebstore format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <div style="display:flex;gap:10px;">
   <a
     title="Chrome extension link"
-    href="https://chrome.google.com/webstore/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
+    href="https://chromewebstore.google.com/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
     target="_blank"
     rel="noopener"
     ><img
@@ -17,7 +17,7 @@
       src="https://flat.badgen.net/chrome-web-store/v/eciepnnimnjaojlkcpdpcgbfkpcagahd?color=fb9836&amp;icon=chrome&amp;label=chrome" /></a
   ><a
     title="Chrome extension link"
-    href="https://chrome.google.com/webstore/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
+    href="https://chromewebstore.google.com/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
     target="_blank"
     rel="noopener"
     ><img
@@ -27,7 +27,7 @@
       src="https://flat.badgen.net/chrome-web-store/users/eciepnnimnjaojlkcpdpcgbfkpcagahd?color=fb9836&amp;icon=chrome" /></a
   ><a
     title="Chrome extension link"
-    href="https://chrome.google.com/webstore/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
+    href="https://chromewebstore.google.com/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd"
     target="_blank"
     rel="noopener"
     ><img
@@ -64,7 +64,7 @@ https://gourav.io/notion-boost
 
 ### ⬇ Downloads
 
-- Chrome/Edge/Brave extension - https://chrome.google.com/webstore/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd
+- Chrome/Edge/Brave extension - https://chromewebstore.google.com/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd
 - Firefox addon - https://addons.mozilla.org/en-US/firefox/addon/notion-boost/
 
 ### ⭐ All Features
@@ -77,7 +77,7 @@ See what's new in latest update: https://gourav.io/notion-boost/whats-new
 
 ---
 
-#### 👍 Liked this extension? express your love by rating [★★★★★](https://chrome.google.com/webstore/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd) on Chrome/Firefox store.
+#### 👍 Liked this extension? express your love by rating [★★★★★](https://chromewebstore.google.com/detail/notion-boost/eciepnnimnjaojlkcpdpcgbfkpcagahd) on Chrome/Firefox store.
 
 <!-- #### ✨ Follow [@NotionBoost](https://twitter.com/intent/follow?user_id=1312809481240154112) on Twitter for many amazing Notion tips & tricks. -->
 


### PR DESCRIPTION
## Summary
Updates deprecated Chrome Web Store URLs (chrome.google.com/webstore) to the new format (chromewebstore.google.com).

## Changes
- `README.md`: Updated 5 extension store links

This fix follows Google's URL migration for the Chrome Web Store.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*