### PR TITLE
Fix Extension Compatibility After Latest Notion Domain Change

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -26,7 +26,7 @@ featureList.hideAiBtn = hideAiBtn;
 featureList.hideTableOfContents = hideTableOfContents;
 
 export default defineContentScript({
-    matches: ['*://*.notion.so/*', '*://*.notion.site/*'],
+    matches: ['*://*.notion.so/*', '*://*.notion.site/*', '*://*.notion.com/*'],
     main() {
         init();
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,7 +36,7 @@ const baseManifest = {
         'Boost Notion productivity with 20+ customizations like outline, small text full width for all, back to top button etc',
     author: 'Gourav Goyal',
     permissions: ['storage'],
-    host_permissions: ['*://*.notion.so/*', '*://*.notion.site/*'],
+    host_permissions: ['*://*.notion.so/*', '*://*.notion.site/*', '*://*.notion.com/*'],
     homepage_url: 'https://gourav.io/notion-boost',
     icons: {
         '16': '/icon/icon16.png',


### PR DESCRIPTION
A maintained fork of the Notion Boost browser extension with updated domain handling to support Notion’s migration to app.notion.com, ensuring continued functionality on the latest Notion web app.