### PR TITLE
Fix: support Notion's new notion.com domain

### DIFF
--- a/components/features/pageElements.ts
+++ b/components/features/pageElements.ts
@@ -499,6 +499,7 @@ function disablePopupOnURLPasteEvent(e: any) {
     if (
         (!content.includes(' ') || content.slice(-1) === ' ') &&
         !content.includes('notion.so') &&
+        !content.includes('notion.com') &&
         content.includes('.')
     ) {
         console.log('inside disablePopupOnURLPasteEvent');

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -26,7 +26,7 @@ featureList.hideAiBtn = hideAiBtn;
 featureList.hideTableOfContents = hideTableOfContents;
 
 export default defineContentScript({
-    matches: ['*://*.notion.so/*', '*://*.notion.site/*'],
+    matches: ['*://*.notion.so/*', '*://*.notion.site/*', '*://*.notion.com/*'],
     main() {
         init();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "notion-boost-browser-extension",
-    "description": "Notion Boost - add outline and more to notion.so",
+    "description": "Notion Boost - add outline and more to Notion",
     "private": false,
     "version": "1.0.0",
     "type": "module",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -36,7 +36,7 @@ const baseManifest = {
         'Boost Notion productivity with 20+ customizations like outline, small text full width for all, back to top button etc',
     author: 'Gourav Goyal',
     permissions: ['storage'],
-    host_permissions: ['*://*.notion.so/*', '*://*.notion.site/*'],
+    host_permissions: ['*://*.notion.so/*', '*://*.notion.site/*', '*://*.notion.com/*'],
     homepage_url: 'https://gourav.io/notion-boost',
     icons: {
         '16': '/icon/icon16.png',


### PR DESCRIPTION
## Problem

Notion migrated its primary app domain from `notion.so` to **`notion.com`**. The extension only targeted `*.notion.so` and `*.notion.site` in its content-script `matches` and `host_permissions`, so on `notion.com` (including `app.notion.com` / `www.notion.com`) the content script never injected — the extension appeared completely dead.

## Changes

- **`entrypoints/content.ts`** — add `*://*.notion.com/*` to content-script `matches`
- **`wxt.config.ts`** — add `*://*.notion.com/*` to `host_permissions`
- **`components/features/pageElements.ts`** — treat pasted `notion.com` URLs as internal Notion links (same handling as `notion.so`) so the embed/bookmark popup isn't auto-dismissed
- **`package.json`** — minor description wording (`notion.so` → `Notion`)

The `*.notion.com` pattern matches the bare domain plus all subdomains (`app.`, `www.`, …). The legacy `notion.so` / `notion.site` patterns are kept so existing users are unaffected.

## Testing

- `pnpm run build` passes; generated `build/chrome-mv3/manifest.json` includes `*://*.notion.com/*` in both `matches` and `host_permissions`.
- Manual: load `build/chrome-mv3` unpacked → open a `notion.com` page → confirm features (outline, back-to-top, etc.) activate; verify `notion.so` pages still work.

## Note for release

Manifest `version` is unchanged (`3.3.6`). Bump it before publishing to the Chrome Web Store, or the upload will be rejected as a duplicate version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
